### PR TITLE
Update `set-output` workflow command. Fix test 

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -118,7 +118,7 @@ jobs:
         echo "value=$ANNOTATIONS" >> $GITHUB_OUTPUT
       env:
         ANNOTATIONS: |
-          {"path":"README.md","start_line":1,"end_line":2,"message":"Check your spelling for 'banaas'.","annotation_level":"warning"}
+          [{"path":"README.md","start_line":1,"end_line":2,"message":"Check your spelling for 'banaas'.","annotation_level":"warning"}]
     - uses: ./
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v1
     - id: annotations
       run: |
-        echo ::set-output name=value::$ANNOTATIONS
+        echo "value=$ANNOTATIONS" >> $GITHUB_OUTPUT
       env:
         ANNOTATIONS: |
           {"path":"README.md","start_line":1,"end_line":2,"message":"Check your spelling for 'banaas'.","annotation_level":"warning"}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/